### PR TITLE
[v1.4] Adds MIssing Device Code Flow Spec

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -55,7 +55,6 @@ jobs:
         run: crystal spec
         env:
           BASE_URL: http://localhost:4000
-          ACTIVATE_URL: http://localhost:4000/activate
           DEVICE_CODE_TTL: 300
           SECRET_KEY: secret_key
           REFRESH_TTL: 60

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Authority
 
+<<<<<<< HEAD
 [![Test](https://github.com/azutoolkit/authority/actions/workflows/spec.yml/badge.svg)](https://github.com/azutoolkit/authority/actions/workflows/spec.yml) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/c19b4551de9f43c2b79664af5908f033)](https://www.codacy.com/gh/azutoolkit/authority/dashboard?utm_source=github.com&utm_medium=referral&utm_content=azutoolkit/authority&utm_campaign=Badge_Grade) ![GitHub release (latest by date)](https://img.shields.io/github/v/release/azutoolkit/authority?label=shard) [![documentation](https://img.shields.io/badge/documentation-authority-brightgreen)](https://azutopia.gitbook.io/authority)
+=======
+[![Test](https://github.com/azutoolkit/authority/actions/workflows/spec.yml/badge.svg)](https://github.com/azutoolkit/authority/actions/workflows/spec.yml) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/c19b4551de9f43c2b79664af5908f033)](https://www.codacy.com/gh/azutoolkit/authority/dashboard?utm_source=github.com&utm_medium=referral&utm_content=azutoolkit/authority&utm_campaign=Badge_Grade) ![GitHub release (latest by date)](https://img.shields.io/github/v/release/azutoolkit/authority?label=shard)
+>>>>>>> 25a95a7 ([v1.4] Adds Device Code Flow)
 
 ![logo](https://user-images.githubusercontent.com/1685772/141647649-241cff93-a5dc-4e6a-9695-ff4b9e6a51d4.png)
 
@@ -111,7 +115,10 @@ TEMPLATES_PATH="./public/templates"
 ERROR_TEMPLATE
 SESSION_KEY="session_id"
 BASE_URL=http://localhost:4000
+<<<<<<< HEAD
 ACTIVATE_URL=http://localhost:4000/activate
+=======
+>>>>>>> 25a95a7 ([v1.4] Adds Device Code Flow)
 DEVICE_CODE_TTL=300
 SSL_CERT=
 SSL_KEY=

--- a/local.env
+++ b/local.env
@@ -10,9 +10,7 @@ SECRET_KEY=secret_key
 REFRESH_TTL=60
 CODE_TTL=5
 ACCESS_TOKEN_TTL=60
-TEMPLATES_PATH="./public/templates"
 ERROR_TEMPLATE
 SESSION_KEY="session_id"
 BASE_URL=http://localhost:4000
-ACTIVATE_URL=http://localhost:4000/activate
 DEVICE_CODE_TTL=300

--- a/spec/device_code_spec.cr
+++ b/spec/device_code_spec.cr
@@ -1,18 +1,44 @@
 require "./spec_helper"
 
 describe Authority do
-  # http_client = OAUTH_CLIENT.http_client
-  # client = create_client
-  # describe "Device Code Flow" do
-  #   it "gets device code" do
-  #     response = http_client.post("/device/code?client_id=#{client.client_id}")
+  http_client = OAUTH_CLIENT.http_client
 
-  #     response.status_code.should eq 201
-  #     # Make request to "/device/code"
-  #     # Response should be
-  #   end
+  describe "Device Code Flow" do
+    it "gets device code" do
+      password = Faker::Internet.password
+      owner = create_owner(password: password)
+      username = owner.username
+      response = http_client.post("/device/code?client_id=#{CLIENT_ID}&scope=read")
 
-  #   it "gets device token" do
-  #   end
-  # end
+      response.status_code.should eq 201
+      json = JSON.parse(response.body)
+
+      json["verification_uri"].should eq "http://localhost:4000/activate"
+
+      verification_url = json["verification_full"].as_s
+      user_code = json["user_code"].as_s
+      device_code = json["device_code"].as_s
+
+      url = DeviceCodeFlux.flow(verification_url, username, password, user_code, "allowed")
+
+      url.should eq "http://localhost:4000/activate"
+
+      response = http_client.post("/device/token", form: {
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code",
+        "code"       => device_code,
+        "client_id"  => CLIENT_ID,
+
+      })
+
+      access_token = JSON.parse(response.body)
+
+      access_token["access_token"].as_s.should_not be_empty
+      access_token["token_type"].as_s.should eq "Bearer"
+      access_token["refresh_token"].as_s.should_not be_empty
+      access_token["access_token"].as_s.should_not be_empty
+    end
+
+    it "gets device token" do
+    end
+  end
 end

--- a/spec/flows/device_code_flux.cr
+++ b/spec/flows/device_code_flux.cr
@@ -1,0 +1,37 @@
+require "flux"
+require "uri"
+
+class DeviceCodeFlux < Flux
+  def self.flow(url, username, password, user_code, verification)
+    new(url, username, password, user_code, verification).call
+  end
+
+  def initialize(
+    @url : String,
+    @username : String,
+    @password : String,
+    @user_code : String,
+    @verification : String
+  )
+    options = Marionette.firefox_options(args: ["-headless"])
+    super(Marionette::Browser::Firefox, options)
+  end
+
+  def call
+    step do
+      visit @url
+
+      fill "#username", @username, by: :css
+      fill "#password", @password, by: :css
+      submit "#signin", by: :css
+
+      sleep 1.seconds
+
+      submit "[value=#{@verification}]", by: :css
+
+      sleep 1.seconds
+
+      return current_url
+    end
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -28,7 +28,11 @@ Clear::SQL.truncate("owners", cascade: true)
 Clear::SQL.truncate("clients", cascade: true)
 create_client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI)
 
-process = Process.new("./bin/server", env: ENV.to_h)
+process = Process.new(
+  "./bin/server",
+  env: ENV.to_h,
+  output: Process::Redirect::Inherit,
+  error: Process::Redirect::Inherit)
 # Wait for process to start
 sleep 1.seconds
 

--- a/src/config/authority.cr
+++ b/src/config/authority.cr
@@ -5,11 +5,11 @@ module Authority
 
   SESSION_KEY     = ENV.fetch "SESSION_KEY", "session_id"
   BASE_URL        = ENV.fetch "BASE_URL", "http://localhost:4000"
-  ACTIVATE_URL    = ENV.fetch "ACTIVATE_URL", "http://localhost:4000/activate"
+  ACTIVATE_URL    = "#{BASE_URL}/activate"
   DEVICE_CODE_TTL = ENV.fetch("DEVICE_CODE_TTL", "300").to_i
 
   configure do |c|
-    # To Server static content
+    c.templates.path = "./public/templates"
     c.router.get "/*", Handler::Static.new
   end
 end


### PR DESCRIPTION
The Device Code grant type is used by browserless or input-constrained
devices in the device flow to exchange a previously obtained device code
for an access token.

The Device Code grant type value is
urn:ietf:params:oauth:grant-type:device_code.